### PR TITLE
Fix: Recalls Page Empty Results (Date Range)

### DIFF
--- a/apps/web/app/recalls/page.tsx
+++ b/apps/web/app/recalls/page.tsx
@@ -68,9 +68,9 @@ export default function RecallsPage() {
         // Use search endpoint when searching
         url = `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/api/v1/recalls?search=${encodeURIComponent(debouncedQuery)}&limit=50`
       } else if (filter === 'all') {
-        url = `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/api/v1/recalls?limit=50`
+        url = `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/api/v1/recalls?limit=50&days=90`
       } else {
-        url = `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/api/v1/recalls?classification=${filter}&limit=50`
+        url = `${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'}/api/v1/recalls?classification=${filter}&limit=50&days=90`
       }
 
       const response = await fetch(url)


### PR DESCRIPTION
Updates the frontend to request recalls from the last 90 days instead of the default 30 days. The seeded data is ~40 days old, causing an empty list with the default filter.